### PR TITLE
feat: optimized performance

### DIFF
--- a/rc/byline.kak
+++ b/rc/byline.kak
@@ -1,135 +1,146 @@
 provide-module byline %{
 
-# Mappings
+	# Mappings
 
-map global "normal" "x" ": byline-drag-down<ret>"
-map global "normal" "X" ": byline-drag-up<ret>"
+	map global "normal" "x" ": byline-drag-down<ret>"
+	map global "normal" "X" ": byline-drag-up<ret>"
 
-# High-level selection expanding and contracting, based on selection direction
+	# High-level selection expanding and contracting, based on selection direction
 
-define-command -hidden byline-drag-down %{
-  evaluate-commands -itersel -no-hooks %{
-    try %{
-      byline-assert-selection-forwards
-      byline-expand-below
-    } catch %{
-      byline-contract-above
-    }
-  }
-}
+	define-command -hidden byline-drag-down %{
+		evaluate-commands -itersel -no-hooks %{
+			try %{
+				byline-assert-selection-forwards
+				byline-expand-below
+			} catch %{
+				byline-contract-above
+			}
+		}
+	}
 
-define-command -hidden byline-drag-up %{
-  evaluate-commands -itersel -no-hooks %{
-    try %{
-      byline-assert-selection-forwards
-      byline-contract-below
-    } catch %{
-      byline-expand-above
-    }
-  }
-}
+	define-command -hidden byline-drag-up %{
+		evaluate-commands -itersel -no-hooks %{
+			try %{
+				byline-assert-selection-forwards
+				byline-contract-below
+			} catch %{
+				byline-expand-above
+			}
+		}
+	}
 
-# Assertions
+	# Assertions
 
-define-command -hidden byline-assert-selection-reduced %{
-  # Selections on blank lines are not considered reduced
-  execute-keys -draft "<a-K>^$<ret>"
-  # Single-character selections are reduced
-  execute-keys -draft "<a-k>\A.{,1}\z<ret>"
-}
+	define-command -hidden byline-assert-selection-reduced %{
+		# Selections on blank lines are not considered reduced
+		execute-keys -draft "<a-K>^$<ret>"
+		# Single-character selections are reduced
+		execute-keys -draft "<a-k>\A.{,1}\z<ret>"
+	}
 
-define-command -hidden byline-assert-selection-forwards %{
-  try %{
-    # If the selection is just the cursor, we treat it as being in the forwards
-    # direction, and can exit early
-    byline-assert-selection-reduced
-  } catch %{
-    # Otherwise, we need to inspect the selection
-    evaluate-commands -no-hooks %sh{
-      cursor_row=$(echo "$kak_selection_desc" | cut -d "," -f 2 | cut -d "." -f 1)
-      anchor_row=$(echo "$kak_selection_desc" | cut -d "," -f 1 | cut -d "." -f 1)
-      [ "$cursor_row" -gt "$anchor_row" ] && exit
-      [ "$cursor_row" -lt "$anchor_row" ] && (echo "fail"; exit)
-      anchor_col=$(echo "$kak_selection_desc" | cut -d "," -f 1 | cut -d "." -f 2)
-      cursor_col=$(echo "$kak_selection_desc" | cut -d "," -f 2 | cut -d "." -f 2)
-      [ "$cursor_col" -lt "$anchor_col" ] && (echo "fail"; exit)
-    }
-  }
-}
+	define-command -hidden byline-assert-selection-forwards %{
+		try %{
+			# If the selection is just the cursor or blank line
+			# , we treat it as being in the forwards
+			# direction, and can exit early
+			byline-assert-selection-reduced
+		} catch %{
+			evaluate-commands -no-hooks -draft -save-regs 'ab' %{
+				# store current cursor pos
+				set-register a %val{cursor_byte_offset}
+				# force cursor forward
+				execute-keys <a-:>
+				# store second cursor pos
+				set-register b %val{cursor_byte_offset}
+				# if the sel faces forward, the cursor hasn't moved
+				# So we paste reg a. the pasted content is now selected.
+				# We can use <a-k> to check whether it matches register b.
+				try %{
+					execute-keys %exp{"aP<a-k>%reg{b}<ret>u}
+				} catch %{
+					# clean up the pasted content if the above
+					# assertion failed
+					execute-keys 'u'
+					# propogate failure to caller
+					fail
+				}
+			}
+		}
+	}
 
-define-command -hidden byline-assert-selection-full-lines %{
-  # Starts at beginning of line
-  execute-keys -draft "<a-:><a-;>;<a-k>\A^<ret>"
-  # Ends at end of line
-  execute-keys -draft "<a-:>;<a-k>$<ret>"
-}
+	define-command -hidden byline-assert-selection-full-lines %{
+		# Starts at beginning of line
+		execute-keys -draft "<a-:><a-;>;<a-k>\A^<ret>"
+		# Ends at end of line
+		execute-keys -draft "<a-:>;<a-k>$<ret>"
+	}
 
-# Low-level selection expanding and contracting primitives
+	# Low-level selection expanding and contracting primitives
 
-define-command -hidden byline-expand-above %{
-  try %{
-    byline-assert-selection-full-lines
-    execute-keys "<a-:><a-;>%val{count}Kx"
-  } catch %{
-    execute-keys "x<a-:><a-;>"
-    evaluate-commands -no-hooks %sh{
-      if [ "$kak_count" -gt 1 ]; then
-        echo "execute-keys '$((kak_count - 1))Kx'"
-      fi
-    }
-  }
-}
+	define-command -hidden byline-expand-above %{
+		try %{
+			byline-assert-selection-full-lines
+			execute-keys "<a-:><a-;>%val{count}Kx"
+		} catch %{
+			execute-keys "x<a-:><a-;>"
+			evaluate-commands -no-hooks %sh{
+				if [ "$kak_count" -gt 1 ]; then
+				echo "execute-keys '$((kak_count - 1))Kx'"
+				fi
+			}
+		}
+	}
 
-define-command -hidden byline-contract-above %{
-  try %{
-    byline-assert-selection-full-lines
-    execute-keys "<a-:><a-;>%val{count}Jx"
-  } catch %{
-    try %{
-      execute-keys "<a-x>"
-    } catch %{
-      execute-keys "x"
-    }
-    execute-keys "<a-:><a-;>"
-    evaluate-commands -no-hooks %sh{
-      if [ "$kak_count" -gt 1 ]; then
-        echo "execute-keys '$((kak_count - 1))Jx'"
-      fi
-    }
-  }
-}
+	define-command -hidden byline-contract-above %{
+		try %{
+			byline-assert-selection-full-lines
+			execute-keys "<a-:><a-;>%val{count}Jx"
+		} catch %{
+			try %{
+				execute-keys "<a-x>"
+			} catch %{
+				execute-keys "x"
+			}
+			execute-keys "<a-:><a-;>"
+			evaluate-commands -no-hooks %sh{
+				if [ "$kak_count" -gt 1 ]; then
+				echo "execute-keys '$((kak_count - 1))Jx'"
+				fi
+			}
+		}
+	}
 
-define-command -hidden byline-expand-below %{
-  try %{
-    byline-assert-selection-full-lines
-    execute-keys "<a-:>%val{count}Jx"
-  } catch %{
-    execute-keys "x<a-:>"
-    evaluate-commands -no-hooks %sh{
-      if [ "$kak_count" -gt 1 ]; then
-        echo "execute-keys '$((kak_count - 1))Jx'"
-      fi
-    }
-  }
-}
+	define-command -hidden byline-expand-below %{
+		try %{
+			byline-assert-selection-full-lines
+			execute-keys "<a-:>%val{count}Jx"
+		} catch %{
+			execute-keys "x<a-:>"
+			evaluate-commands -no-hooks %sh{
+				if [ "$kak_count" -gt 1 ]; then
+				echo "execute-keys '$((kak_count - 1))Jx'"
+				fi
+			}
+		}
+	}
 
-define-command -hidden byline-contract-below %{
-  try %{
-    byline-assert-selection-full-lines
-    execute-keys "<a-:>%val{count}Kx"
-  } catch %{
-    try %{
-      execute-keys "<a-x>"
-    } catch %{
-      execute-keys "x"
-    }
-    execute-keys "<a-:>"
-    evaluate-commands -no-hooks %sh{
-      if [ "$kak_count" -gt 1 ]; then
-        echo "execute-keys '$((kak_count - 1))Kx'"
-      fi
-    }
-  }
-}
+	define-command -hidden byline-contract-below %{
+		try %{
+			byline-assert-selection-full-lines
+			execute-keys "<a-:>%val{count}Kx"
+		} catch %{
+			try %{
+				execute-keys "<a-x>"
+			} catch %{
+				execute-keys "x"
+			}
+			execute-keys "<a-:>"
+			evaluate-commands -no-hooks %sh{
+				if [ "$kak_count" -gt 1 ]; then
+				echo "execute-keys '$((kak_count - 1))Kx'"
+				fi
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
This PR refactors the `byline-assert-selection-forwards` command for a `~17x` performance gain according to my profiling. The existing implementation of the command is very expensive. Including the shell, it spawns 15 subprocesses. Since this command is invoked every single time you press `x` or `X`, holding down the key causes Kakoune to freeze temporarily on slower hardware.

I refactored the command to use only Kakoune commands without any subshell. This took its performance from around `5500 us` to under `300 us` on each invocation. I'll briefly explain how it works:

1. I didn't touch the `byline-assert-selection-reduced` command because it doesn't spawn any subprocesses.
2. In the `catch` block, we start a new `eval` block with `-nohooks -draft -saveregs 'ab'`.
3. We save the cursor's current position to register `a`.
4. We use `<a-:>` to force the selection forward.
5. We save the cursor position to register `b`.
6. We paste the contents of register `a`, and we use `<a-k>` to check whether it matches register `b`.
7. If they match, it means `<a-:>` hasn't moved the cursor at all, which means the selection is facing forward.
8. Because we pasted into the buffer, we undo the change with `u`.

The result is identical behavior, but **significantly** faster.

PS. I also reformatted the script. Hope that's not an issue, since I didn't see any style guidelines.